### PR TITLE
Centralize server address configuration

### DIFF
--- a/src/configs/aplication.go
+++ b/src/configs/aplication.go
@@ -11,11 +11,13 @@ import (
 const (
 	DEFAULT_ROUTE_VERSION = "1"     // Default version for the API routes
 	DEFAULT_API_VERSION   = "0.1.0" // Default version for the API
+	DEFAULT_ADDRESS       = ":8080" // Default server address
 )
 
 type appType struct {
 	apiVersion    types.Version
 	routesVersion uint32
+	address       string
 }
 
 var App appType
@@ -44,6 +46,8 @@ func envInit() {
 		appVersion = types.V(DEFAULT_API_VERSION)
 	}
 	App.apiVersion = appVersion
+
+	App.address = cmp.Or(os.Getenv("SERVER_ADDRESS"), DEFAULT_ADDRESS)
 }
 
 func (appType) RoutesVersion() uint32 {
@@ -52,4 +56,8 @@ func (appType) RoutesVersion() uint32 {
 
 func (appType) ApiVersion() types.Version {
 	return App.apiVersion
+}
+
+func (appType) Address() string {
+	return App.address
 }

--- a/src/main.go
+++ b/src/main.go
@@ -1,9 +1,6 @@
 package main
 
 import (
-	"cmp"
-	"os"
-
 	"github.com/gin-gonic/gin"
 	_ "github.com/joho/godotenv/autoload"
 
@@ -20,12 +17,6 @@ func init() {
 	// configs.DB.Migrate(&models.StudentDBMongo{})
 	logger.Info("Env configurations loaded")
 	logger.Debug("Starting server")
-}
-
-// address returns the server address from the environment variable
-func address() string {
-	envAddress := os.Getenv("SERVER_ADDRESS")
-	return cmp.Or(envAddress, ":8080")
 }
 
 func main() {
@@ -54,5 +45,5 @@ func main() {
 	routes.SessionTypeRoutes(router)
 	routes.SessionRoutes(router)
 
-	router.Run(address()) // listen and serve on 0.0.0.0:8080 (for windows ":8080")
+	router.Run(configs.App.Address()) // listen and serve on 0.0.0.0:8080 (for windows ":8080")
 }


### PR DESCRIPTION
Moved server address logic from main.go to configs/aplication.go, adding an Address field and accessor to appType. This improves configuration management by centralizing the server address and removing redundant code from main.go.