### PR TITLE
Update deploy workflow to trigger on 'prod' branch

### DIFF
--- a/.github/workflows/deploy-gcp.yml
+++ b/.github/workflows/deploy-gcp.yml
@@ -3,7 +3,7 @@ name: 'Deploy release for this production service'
 on:
   push:
     branches:
-      - "main"
+      - "prod"
 jobs:
   pipeline:
     name: Skaffold Docker build


### PR DESCRIPTION
Changed the GitHub Actions workflow to run on pushes to the 'prod' branch instead of 'main' for production deployments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **No user-facing changes**
  * This release contains internal infrastructure updates only and does not affect end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->